### PR TITLE
Removed loadViewsFrom() from NovaSettingsServiceProvider

### DIFF
--- a/src/NovaSettingsServiceProvider.php
+++ b/src/NovaSettingsServiceProvider.php
@@ -20,7 +20,6 @@ class NovaSettingsServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'nova-settings');
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         $this->loadTranslations(__DIR__ . '/../lang', 'nova-settings', true);
 


### PR DESCRIPTION
Thanks for the package!

I use the following versions:

```
laravel/framework                    v9.9.0  The Laravel Framework.
laravel/nova                         4.2.5   A wonderful administration interface for Laravel.
optimistdigital/nova-settings        4.0.2   A Laravel Nova tool for editing custom settings using native Nova fields.
```

If you use `artisan view:cache` the console generate the following error:

```bash
pa view:cache
Compiled views cleared successfully.

   Symfony\Component\Finder\Exception\DirectoryNotFoundException 

  The "/Users/nils/Sites/foobar/vendor/optimistdigital/nova-settings/src/../resources/views" directory does not exist.

  at vendor/symfony/finder/Finder.php:590
    586▕             } elseif ($glob = glob($dir, (\defined('GLOB_BRACE') ? \GLOB_BRACE : 0) | \GLOB_ONLYDIR | \GLOB_NOSORT)) {
    587▕                 sort($glob);
    588▕                 $resolvedDirs[] = array_map([$this, 'normalizeDir'], $glob);
    589▕             } else {
  ➜ 590▕                 throw new DirectoryNotFoundException(sprintf('The "%s" directory does not exist.', $dir));
    591▕             }
    592▕         }
    593▕ 
    594▕         $this->dirs = array_merge($this->dirs, ...$resolvedDirs);

      +17 vendor frames 
  18  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

You don't use blade views anymore. So I deleted the loadViewsFrom() from NovaSettingsServiceProvider.