### PR TITLE
Bugfix/empty var check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.5] - 25-04-2022
+
+### Changed
+
+- Changed `empty` check to `isset` when loading settings to allow negative but defined values.
+
 ## [3.5.4] - 08-04-2022
 
 ### Changed

--- a/src/NovaSettingsStore.php
+++ b/src/NovaSettingsStore.php
@@ -76,7 +76,7 @@ class NovaSettingsStore
             return collect($settingKeys)->flatMap(function ($settingKey) use ($settings, $defaults) {
                 $settingValue = $settings[$settingKey] ?? null;
 
-                if (!empty($settingValue)) {
+                if (isset($settingValue)) {
                     $this->cache[$settingKey] = $settingValue;
                     return [$settingKey => $settingValue];
                 } else {


### PR DESCRIPTION

Changed `empty` check to `isset` when loading settings to allow negative but defined values.

Fixes issues where default value for key is set to `true` in `nova_get_settings` and in database the value is `false` but default is loaded instead.
