### PR TITLE
Fixed menu item title

### DIFF
--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -28,7 +28,7 @@ class NovaSettings extends Tool
 
         $menuItems = [];
         foreach ($fields as $key => $fields) {
-            $menuItems[] = MenuItem::link(__("novaSettings.{$key}"), "{$basePath}/{$key}");
+            $menuItems[] = MenuItem::link(self::getPageName($key), "{$basePath}/{$key}");
         }
 
 


### PR DESCRIPTION
The menu show translation keys.
This fix uses the getPageName function.

<img width="197" alt="image" src="https://user-images.githubusercontent.com/28200451/166251707-e34f5de3-f588-4734-93f7-afad4d9a933b.png">