### PR TITLE
Fix missing semicolons on migrations

### DIFF
--- a/database/migrations/2019_08_13_000000_create_nova_settings_table.php
+++ b/database/migrations/2019_08_13_000000_create_nova_settings_table.php
@@ -30,4 +30,4 @@ return new class extends Migration
     {
         Schema::dropIfExists(NovaSettings::getSettingsTableName());
     }
-}
+};

--- a/database/migrations/2021_02_15_000000_update_nova_settings_value_column.php
+++ b/database/migrations/2021_02_15_000000_update_nova_settings_value_column.php
@@ -31,4 +31,4 @@ return new class extends Migration
     {
         // No down because previous migration was also modified
     }
-}
+};


### PR DESCRIPTION
The migrations are missing semicolons. This results in a syntax error on PHP 8.1.