### PR TITLE
fix: showing 404 not login route when unauthenticated

### DIFF
--- a/src/NovaSettingsServiceProvider.php
+++ b/src/NovaSettingsServiceProvider.php
@@ -9,6 +9,8 @@ use Outl1ne\NovaSettings\Http\Middleware\Authorize;
 use Outl1ne\NovaTranslationsLoader\LoadsNovaTranslations;
 use Outl1ne\NovaSettings\Http\Middleware\SettingsPathExists;
 
+use Laravel\Nova\Http\Middleware\Authenticate;
+
 class NovaSettingsServiceProvider extends ServiceProvider
 {
     use LoadsNovaTranslations;
@@ -55,7 +57,7 @@ class NovaSettingsServiceProvider extends ServiceProvider
         // Register nova routes
         Nova::router()->group(function ($router) {
             $path = config('nova-settings.base_path', 'nova-settings');
-            $router->get("{$path}/{pageId?}", fn ($pageId = 'general') => inertia('NovaSettings', ['basePath' => $path, 'pageId' => $pageId]));
+            $router->get("{$path}/{pageId?}", fn ($pageId = 'general') => inertia('NovaSettings', ['basePath' => $path, 'pageId' => $pageId]))->middleware(['nova', Authenticate::class]);
         });
 
         if ($this->app->routesAreCached()) return;


### PR DESCRIPTION
- Resolves an issue where 404 would be displayed instead of the login route when trying to view any settings pages when logged out