### PR TITLE
Help text not shown

### DIFF
--- a/resources/js/views/Settings.vue
+++ b/resources/js/views/Settings.vue
@@ -14,6 +14,7 @@
           mode="form"
           class="mb-6"
           :validation-errors="validationErrors"
+          :show-help-text="true"
         />
       </template>
       <!-- Update Button -->


### PR DESCRIPTION
If there is no relevant prop, help text will not render on the panel component, for render the help text on the panel componet,  needs the "showHelpText" props to render the help.

![Screen Shot 2022-09-08 at 15 08 07](https://user-images.githubusercontent.com/15654470/189117983-16e7a2b7-dd09-4031-a3da-0b9637075bfb.png)