### PR TITLE
Allow objects to be Json encoded

### DIFF
--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -27,7 +27,9 @@ class Settings extends Model
 
     public function setValueAttribute($value)
     {
-        $this->attributes['value'] = is_array($value) ? json_encode($value) : $value;
+        $this->attributes['value'] = is_array($value) || is_object($value) && $value instanceof JsonSerializable
+            ? json_encode($value) 
+            : $value;
     }
 
     public function getValueAttribute($value)

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -27,7 +27,7 @@ class Settings extends Model
 
     public function setValueAttribute($value)
     {
-        $this->attributes['value'] = is_array($value) || is_object($value) && $value instanceof JsonSerializable
+        $this->attributes['value'] = is_array($value) || (is_object($value) && $value instanceof \JsonSerializable)
             ? json_encode($value) 
             : $value;
     }

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -27,7 +27,7 @@ class Settings extends Model
 
     public function setValueAttribute($value)
     {
-        $this->attributes['value'] = is_array($value) || (is_object($value) && $value instanceof \JsonSerializable)
+        $this->attributes['value'] = is_array($value) || $value instanceof \JsonSerializable
             ? json_encode($value) 
             : $value;
     }


### PR DESCRIPTION
Allow objects that are instances of JsonSerializable to be properly json encoded.

This will fix compatibility with third party packages such as [nova filemanager](https://github.com/oneduo/nova-file-manager)