### PR TITLE
Link MenuSection directly when there is only one page

### DIFF
--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -26,15 +26,22 @@ class NovaSettings extends Tool
 
         if (!$isAuthorized || !$showInSidebar || empty($fields)) return null;
 
-        $menuItems = [];
-        foreach ($fields as $key => $fields) {
-            $menuItems[] = MenuItem::link(self::getPageName($key), "{$basePath}/{$key}");
+        if (count($fields) == 1) {
+            
+            return MenuSection::make(__('novaSettings.navigationItemTitle'))
+                ->path($basePath . '/' . array_key_first($fields))
+                ->icon('adjustments');
+        } 
+        else {
+            $menuItems = [];
+            foreach ($fields as $key => $fields) {
+                $menuItems[] = MenuItem::link(self::getPageName($key), "{$basePath}/{$key}");
+            }
+
+            return MenuSection::make(__('novaSettings.navigationItemTitle'), $menuItems)
+                ->icon('adjustments')
+                ->collapsable();
         }
-
-
-        return MenuSection::make(__('novaSettings.navigationItemTitle'), $menuItems)
-            ->icon('adjustments')
-            ->collapsable();
     }
 
     public static function getSettingsTableName(): string


### PR DESCRIPTION
This change adjusts the settings menu so that a single page of settings will result in a MenuSection that links directly to the settings page, rather than having a single child MenuItem. 

I think this makes more sense than having a single item display in a submenu.



