### PR TITLE
feat: add optional authorization at page level

### DIFF
--- a/config/nova-settings.php
+++ b/config/nova-settings.php
@@ -30,5 +30,11 @@ return [
     /**
      * Show the sidebar menu
      */
-    'show_in_sidebar' => true
+    'show_in_sidebar' => true,
+
+    /**
+     * Default value for page authorizations. 
+     * "true" = show if not defined, "false" = hide if not defined
+     */
+    'default_page_authorization' => true
 ];

--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -26,6 +26,8 @@ class NovaSettings extends Tool
 
         if (!$isAuthorized || !$showInSidebar || empty($fields)) return null;
 
+        $fields = array_filter($fields, fn ($field) => self::canSeePage($field), ARRAY_FILTER_USE_KEY);
+
         if (count($fields) == 1) {
             
             return MenuSection::make(__('novaSettings.navigationItemTitle'))
@@ -85,9 +87,9 @@ class NovaSettings extends Tool
      * @param array|callable $fields Array of fields/panels to be displayed or callable that returns an array.
      * @param array $casts Associative array same as Laravel's $casts on models.
      **/
-    public static function addSettingsFields($fields = [], $casts = [], $path = 'general')
+    public static function addSettingsFields($fields = [], $casts = [], $path = 'general', $authorization = null)
     {
-        return static::getStore()->addSettingsFields($fields, $casts, $path);
+        return static::getStore()->addSettingsFields($fields, $casts, $path, $authorization);
     }
 
     /**
@@ -104,6 +106,11 @@ class NovaSettings extends Tool
     {
         if (!$path) return static::getStore()->getRawFields();
         return static::getStore()->getFields($path);
+    }
+
+    public static function canSeePage($path)
+    {
+        return static::getStore()->getAuthorization($path);
     }
 
     public static function clearFields()

--- a/src/NovaSettingsStore.php
+++ b/src/NovaSettingsStore.php
@@ -9,8 +9,9 @@ class NovaSettingsStore
     protected $cache = [];
     protected $fields = [];
     protected $casts = [];
+    protected $authorizations = [];
 
-    public function addSettingsFields($fields = [], $casts = [], $path = 'general')
+    public function addSettingsFields($fields = [], $casts = [], $path = 'general', $authorization = null)
     {
         $path = Str::lower(Str::slug($path));
 
@@ -18,6 +19,8 @@ class NovaSettingsStore
         $this->fields[$path] = array_merge($this->fields[$path] ?? [], $fields ?? []);
 
         $this->casts = array_merge($this->casts, $casts ?? []);
+
+        $this->authorizations[$path] = $authorization ?? config('nova-settings.default_page_authorization', Settings::class);
 
         return $this;
     }
@@ -46,6 +49,11 @@ class NovaSettingsStore
         }
 
         return $fields;
+    }
+
+    public function getAuthorization($path = 'general')
+    {
+        return $this->authorizations[$path];
     }
 
     public function getCasts()


### PR DESCRIPTION
Hello, I've been using this package for a bit and was having issues with using the settings globally, but also restricting access to some of the pages. 

I added an `authorization` parameter to the `addSettingsFields` methods and used it to filter the pages on the Nova side. That way the settings are available outside Nova, but still restricted to people with permission. There is also a config for whether the default should be to hide or show if `authorization` is null. 

Let me know if you think it's useful or if there's anything that I should change. No worries if it's too far out of scope for the project. Thanks!