### PR TITLE
Spanish localisation

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -1,0 +1,7 @@
+{
+  "novaSettings.navigationItemTitle": "Configuración",
+  "novaSettings.saveButtonText": "Guardar configuración",
+  "novaSettings.noSettingsFieldsText": "No se ha definido ningún campo de configuración.",
+  "novaSettings.settingsSuccessToast": "¡La configuración se ha actualizado correctamente!",
+  "novaSettings.general": "General"
+}


### PR DESCRIPTION
Introduces a new JSON file that contains Spanish translations for the Nova Settings user interface. The translated elements include navigation item title, save button text, no settings fields text, settings success message, and general settings.