### PR TITLE
Introducing caching options

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,12 @@ The config file can be published using the following command:
 php artisan vendor:publish --provider="Outl1ne\NovaSettings\NovaSettingsServiceProvider" --tag="config"
 ```
 
-| Name                  | Type    | Default           | Description                                                                        |
-| --------------------- | ------- | ----------------- | ---------------------------------------------------------------------------------- |
-| `base_path`           | String  | `nova-settings`   | URL path of settings page.                                                         |
-| `reload_page_on_save` | Boolean | false             | Reload the entire page on save. Useful when updating any Nova UI related settings. |
-| `models.settings`     | Model   | `Settings::class` | Optionally override the Settings model.                                            |
+| Name                  | Type    | Default           | Description                                                                                      |
+|-----------------------|---------|-------------------|--------------------------------------------------------------------------------------------------|
+| `base_path`           | String  | `nova-settings`   | URL path of settings page.                                                                       |
+| `reload_page_on_save` | Boolean | false             | Reload the entire page on save. Useful when updating any Nova UI related settings.               |
+| `models.settings`     | Model   | `Settings::class` | Optionally override the Settings model.                                                          |
+| `cache`               | String  | `:memory:`        | Cache store name to use that cache, ":memory:" for singleton class, or null to turn off caching. |
 
 The migration can also be published and overwritten using:
 

--- a/config/nova-settings.php
+++ b/config/nova-settings.php
@@ -30,5 +30,22 @@ return [
     /**
      * Show the sidebar menu
      */
-    'show_in_sidebar' => true
+    'show_in_sidebar' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache settings
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which of the cache connection should be used to
+    | cache the settings. `:memory:` is the default which is a simple
+    | in-memory cache through a singleton service class property.
+    | `null` will disable caching.
+    |
+    */
+    'cache' => [
+        'store' => env('NOVA_SETTINGS_CACHE_DRIVER', ':memory:'),
+
+        'prefix' => 'nova-settings:',
+    ],
 ];

--- a/src/NovaSettingsCacheStore.php
+++ b/src/NovaSettingsCacheStore.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Outl1ne\NovaSettings;
+
+use Illuminate\Support\Facades\Cache;
+
+use function collect;
+use function is_array;
+use function is_string;
+
+class NovaSettingsCacheStore extends NovaSettingsStore
+{
+    /** @var \Illuminate\Contracts\Cache\Repository */
+    private $cache;
+
+    public function __construct()
+    {
+        $this->cache = Cache::store(config('nova-settings.cache.store'));
+    }
+
+    public function clearCache($keyNames = null)
+    {
+        // Clear whole cache
+        if (empty($keyNames)) {
+            $this->getSettingsModelClass()::all(['key'])->each(function ($setting) {
+                $this->cache->forget($this->getCacheKey($setting->key));
+            });
+
+            return;
+        }
+
+        // Clear specific keys
+        if (is_string($keyNames)) $keyNames = [$keyNames];
+        foreach ($keyNames as $key) {
+            $this->cache->forget($this->getCacheKey($key));
+        }
+    }
+
+    protected function getCached($keyNames = null)
+    {
+        if (is_string($keyNames)) {
+            return $this->cache->get($this->getCacheKey($keyNames));
+        }
+
+        if (is_array($keyNames)) {
+            return collect($keyNames)
+                ->mapWithKeys(function ($key) {
+                    if (!$this->cache->has($this->getCacheKey($key))) return [];
+
+                    return [$key => $this->getCached($key)];
+                })
+                ->toArray();
+        }
+
+        return [];
+    }
+
+    protected function setCached($keyName, $value)
+    {
+        $this->cache->forever($this->getCacheKey($keyName), $value);
+    }
+
+    private function getCacheKey($key)
+    {
+        return config('nova-settings.cache.prefix', 'nova-settings:') . $key;
+    }
+}

--- a/src/NovaSettingsInMemoryStore.php
+++ b/src/NovaSettingsInMemoryStore.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Outl1ne\NovaSettings;
+
+use function collect;
+use function is_array;
+use function is_string;
+
+class NovaSettingsInMemoryStore extends NovaSettingsStore
+{
+    protected $cache = [];
+
+    public function clearCache($keyNames = null)
+    {
+        // Clear whole cache
+        if (empty($keyNames)) {
+            $this->cache = [];
+            return;
+        }
+
+        // Clear specific keys
+        if (is_string($keyNames)) $keyNames = [$keyNames];
+        foreach ($keyNames as $key) {
+            unset($this->cache[$key]);
+        }
+    }
+
+    protected function getCached($keyNames = null)
+    {
+        if (is_string($keyNames)) return $this->cache[$keyNames] ?? null;
+
+        return is_array($keyNames) && !empty($keyNames)
+            ? collect($this->cache)->only($keyNames)->toArray()
+            : $this->cache;
+    }
+
+    protected function setCached($keyName, $value)
+    {
+        $this->cache[$keyName] = $value;
+    }
+}

--- a/src/NovaSettingsNoCacheStore.php
+++ b/src/NovaSettingsNoCacheStore.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Outl1ne\NovaSettings;
+
+use function is_string;
+
+class NovaSettingsNoCacheStore extends NovaSettingsStore
+{
+    public function clearCache($keyNames = null)
+    {
+    }
+
+    protected function getCached($keyNames = null)
+    {
+        if (is_string($keyNames)) return null;
+
+        return [];
+    }
+
+    protected function setCached($keyName, $value)
+    {
+    }
+}

--- a/src/NovaSettingsStore.php
+++ b/src/NovaSettingsStore.php
@@ -99,8 +99,10 @@ abstract class NovaSettingsStore
         }
 
         return $this->getSettingsModelClass()::all()
-            ->tap(function ($setting) {
-                $this->setCached($setting->key, $setting->value);
+            ->tap(function ($settings) {
+                $settings->each(function ($setting) {
+                    $this->setCached($setting->key, $setting->value);
+                });
             })
             ->pluck('value', 'key')
             ->toArray();

--- a/src/NovaSettingsStore.php
+++ b/src/NovaSettingsStore.php
@@ -4,9 +4,17 @@ namespace Outl1ne\NovaSettings;
 
 use Illuminate\Support\Str;
 
-class NovaSettingsStore
+use function array_diff;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function call_user_func;
+use function collect;
+use function is_array;
+use function is_callable;
+
+abstract class NovaSettingsStore
 {
-    protected $cache = [];
     protected $fields = [];
     protected $casts = [];
 
@@ -55,29 +63,33 @@ class NovaSettingsStore
 
     public function getSetting($settingKey, $default = null)
     {
-        if (isset($this->cache[$settingKey])) return $this->cache[$settingKey];
-        $this->cache[$settingKey] = NovaSettings::getSettingsModel()::getValueForKey($settingKey) ?? $default;
-        return $this->cache[$settingKey];
+        if ($cached = $this->getCached($settingKey)) return $cached;
+
+        $settingValue = $this->getSettingsModelClass()::getValueForKey($settingKey) ?? $default;
+
+        $this->setCached($settingKey, $settingValue);
+
+        return $settingValue;
     }
 
     public function getSettings(array $settingKeys = null, array $defaults = [])
     {
-        $settingsModel = NovaSettings::getSettingsModel();
-
         if (!empty($settingKeys)) {
-            $hasMissingKeys = !empty(array_diff($settingKeys, array_keys($this->cache)));
+            $cached = $this->getCached($settingKeys);
 
-            if (!$hasMissingKeys) return collect($settingKeys)->mapWithKeys(function ($settingKey) {
-                return [$settingKey => $this->cache[$settingKey]];
-            })->toArray();
+            $hasMissingKeys = !empty(array_diff($settingKeys, array_keys($cached)));
 
-            $settings = $settingsModel::whereIn('key', $settingKeys)->get()->pluck('value', 'key');
+            if (!$hasMissingKeys) return $cached;
+
+            $settings = $this->getSettingsModelClass()::whereIn('key', $settingKeys)
+                ->get()
+                ->pluck('value', 'key');
 
             return collect($settingKeys)->flatMap(function ($settingKey) use ($settings, $defaults) {
                 $settingValue = $settings[$settingKey] ?? null;
 
                 if (isset($settingValue)) {
-                    $this->cache[$settingKey] = $settingValue;
+                    $this->setCached($settingKey, $settingValue);
                     return [$settingKey => $settingValue];
                 } else {
                     $defaultValue = $defaults[$settingKey] ?? null;
@@ -86,40 +98,44 @@ class NovaSettingsStore
             })->toArray();
         }
 
-        return $settingsModel::all()->map(function ($setting) {
-            $this->cache[$setting->key] = $setting->value;
-            return $setting;
-        })->pluck('value', 'key')->toArray();
+        return $this->getSettingsModelClass()::all()
+            ->tap(function ($setting) {
+                $this->setCached($setting->key, $setting->value);
+            })
+            ->pluck('value', 'key')
+            ->toArray();
     }
 
     public function setSettingValue($settingKey, $value = null)
     {
-        $setting = NovaSettings::getSettingsModel()::firstOrCreate(['key' => $settingKey]);
+        $setting = $this->getSettingsModelClass()::firstOrCreate(['key' => $settingKey]);
         $setting->value = $value;
         $setting->save();
-        unset($this->cache[$settingKey]);
+
+        $this->setCached($settingKey, $setting->value);
+
         return $setting;
     }
 
-    public function clearCache($keyNames = null)
-    {
-        // Clear whole cache
-        if (empty($keyNames)) {
-            $this->cache = [];
-            return;
-        }
-
-        // Clear specific keys
-        if (is_string($keyNames)) $keyNames = [$keyNames];
-        foreach ($keyNames as $key) {
-            unset($this->cache[$key]);
-        }
-    }
+    public abstract function clearCache($keyNames = null);
 
     public function clearFields()
     {
         $this->fields = [];
         $this->casts = [];
-        $this->cache = [];
+
+        $this->clearCache();
+    }
+
+    protected abstract function getCached($keyNames = null);
+
+    protected abstract function setCached($keyName, $value);
+
+    /**
+     * @return class-string<\Outl1ne\NovaSettings\Models\Settings>
+     */
+    protected function getSettingsModelClass()
+    {
+        return NovaSettings::getSettingsModel();
     }
 }


### PR DESCRIPTION
The current flow is that the singleton service class is using class property as cache ("in-memory"), however, this can cause problems in background processes (incl. Horizon / Queue) and if the app is utilising Laravel Octane.

There are 3 options now:
- in memory caching (default, previous)
- using a configured cache store (e.g. Redis)
- no caching at all

I will have no time to add tests, really sorry. Feel free to close this PR if that's a problem and no one can add them.

Relates to #182 .