### PR TITLE
fix: change icon name to heroicon v2 name

### DIFF
--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -29,7 +29,7 @@ class NovaSettings extends Tool
         if (count($fields) == 1) {
             return MenuSection::make(__('novaSettings.navigationItemTitle'))
                 ->path($basePath . '/' . array_key_first($fields))
-                ->icon('adjustments');
+                ->icon('adjustments-vertical');
         } else {
             $menuItems = [];
             foreach ($fields as $key => $fields) {
@@ -37,7 +37,7 @@ class NovaSettings extends Tool
             }
 
             return MenuSection::make(__('novaSettings.navigationItemTitle'), $menuItems)
-                ->icon('adjustments')
+                ->icon('adjustments-vertical')
                 ->collapsable();
         }
     }


### PR DESCRIPTION
The `adjustments` icon in the menu no longer exists in Laravel Nova 5, as it has switched to Heroicon v2.

Replaced the icon name with `adjustments-vertical`, which is a valid Heroicon v2 icon.